### PR TITLE
Python bindings: use jrl-cmakemodules for the install process.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-RBDynUrdf read urdf file and convert it in RBDyn MultiBodyGraph.
+RBDynUrdf
+=========
+
+RBDynUrdf reads URDF files and converts them to RBDyn MultiBodyGraph.
+
+## Install
+
+```sh
+mkdir build && cd build
+cmake .. -DCMAKE_INSTALL_PREFIX="/your/install/prefix" -DCMAKE_BUILD_TYPE=RelWithDebInfo
+make
+make install
+```
+
+Note: if you are on a Debian-based distribution (e.g. Ubuntu), you may want to
+add the `-DPYTHON_DEB_LAYOUT` flag to the `cmake` command in order to install
+this package with the specific Debian layout.

--- a/binding/python/CMakeLists.txt
+++ b/binding/python/CMakeLists.txt
@@ -1,48 +1,36 @@
 INCLUDE(../../cmake/python.cmake)
+
+# Look for Python 2.7
+SET(Python_ADDITIONAL_VERSIONS 2.7)
 FINDPYTHON()
 
-## Define PYTHON_DISTLIB
-EXECUTE_PROCESS(
-  COMMAND "${PYTHON_EXECUTABLE}" "-c"
-  "import sys, os; print os.sep.join(['lib', 'python' + sys.version[:3], 'dist-packages'])"
-  OUTPUT_VARIABLE PYTHON_DISTLIB
-  ERROR_QUIET)
-# Remove final \n of the variable PYTHON_DISTLIB
-STRING(REPLACE "\n" "" PYTHON_DISTLIB "${PYTHON_DISTLIB}")
+# Create the package in build dir for testing purpose
+SET(LIBRARY_OUTPUT_PATH ${CMAKE_CURRENT_BINARY_DIR}/rbdyn_urdf)
+CONFIGURE_FILE(__init__.py ${CMAKE_CURRENT_BINARY_DIR}/rbdyn_urdf/__init__.py COPYONLY)
+SET(OUTPUT_BINDING ${CMAKE_CURRENT_BINARY_DIR}/rbdyn_urdf.cpp)
 
-
-# RBDynUrdf
-
-# create the package in build dir for testing purpose
-set(LIBRARY_OUTPUT_PATH ${CMAKE_CURRENT_BINARY_DIR}/rbdyn_urdf)
-configure_file(__init__.py ${CMAKE_CURRENT_BINARY_DIR}/rbdyn_urdf/__init__.py COPYONLY)
-
-set(OUTPUT_BINDING ${CMAKE_CURRENT_BINARY_DIR}/rbdyn_urdf.cpp)
-
-# generate python binding code
-add_custom_command (
+# Generate Python binding code
+ADD_CUSTOM_COMMAND (
   OUTPUT ${OUTPUT_BINDING}
   COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/generate.py ${OUTPUT_BINDING}
   DEPENDS generate.py
 )
 
-# build the library
-set(SOURCES ${OUTPUT_BINDING})
-include_directories(.)
-include_directories(../../src)
-include_directories(${PYTHON_INCLUDE_DIRS})
+# Build the library
+SET(SOURCES ${OUTPUT_BINDING})
 
-add_library(_rbdyn_urdf SHARED ${SOURCES})
+INCLUDE_DIRECTORIES(SYSTEM ${PYTHON_INCLUDE_PATH})
+INCLUDE_DIRECTORIES(.)
+INCLUDE_DIRECTORIES(../../src)
+
+ADD_LIBRARY(_rbdyn_urdf SHARED ${SOURCES})
 PKG_CONFIG_USE_DEPENDENCY(_rbdyn_urdf urdfdom_headers)
 PKG_CONFIG_USE_DEPENDENCY(_rbdyn_urdf urdfdom)
 PKG_CONFIG_USE_DEPENDENCY(_rbdyn_urdf RBDyn)
 
-target_link_libraries(_rbdyn_urdf RBDynUrdf)
-set_target_properties(_rbdyn_urdf PROPERTIES PREFIX "")
+TARGET_LINK_LIBRARIES(_rbdyn_urdf RBDynUrdf)
+SET_TARGET_PROPERTIES(_rbdyn_urdf PROPERTIES PREFIX "")
 
-
-# install rules
-set(INSTALL_PATH "${PYTHON_DISTLIB}/rbdyn_urdf/")
-install(TARGETS _rbdyn_urdf DESTINATION ${INSTALL_PATH})
-install(FILES __init__.py DESTINATION ${INSTALL_PATH})
-
+# Install rules
+INSTALL(TARGETS _rbdyn_urdf DESTINATION "${PYTHON_SITELIB}/rbdyn_urdf")
+PYTHON_INSTALL_BUILD(rbdyn_urdf __init__.py "${PYTHON_SITELIB}")


### PR DESCRIPTION
This solves the dist/site-packages issues with non-Debian distributions.
